### PR TITLE
making RPI dependencies optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+![py-micro-hil](https://github.com/user-attachments/assets/df04bf2b-8f0e-4f82-8d09-2250c391630a)
 # Py-Micro-HIL
 
 > **Py-Micro-HIL** is a modular, lightweight **Hardware-in-the-Loop (HIL) testing framework** for Python.  
@@ -29,10 +30,20 @@ With this framework you can:
 
 ## ⚙️ Installation
 
+Default installs are for **PC simulation**, CI, and non-Pi Linux (no `RPi.GPIO` / `spidev` / `smbus2` wheels required). On a **Raspberry Pi** with real GPIO, SPI, or I2C hardware, add the **`rpi`** extra.
+
 ### 🧰 Option 1 – From PyPI (recommended for most users)
+
+PC / simulation / CI:
 
 ```bash
 pip install py-micro-hil
+```
+
+Raspberry Pi with real hardware libraries:
+
+```bash
+pip install 'py-micro-hil[rpi]'
 ```
 
 ### 🧪 Option 2 – From source (for contributors)
@@ -43,6 +54,18 @@ cd PY_MICRO_HIL
 pip install -e .
 ```
 
+With dev tools only (same as PC default — no Pi-specific wheels):
+
+```bash
+pip install -e ".[dev]"
+```
+
+On a Raspberry Pi, include hardware dependencies:
+
+```bash
+pip install -e ".[dev,rpi]"
+```
+
 > 💡 On your hil test server, you can use the flag `--break-system-packages` to simplify installation and usage for CI/CD environments:
 > ```bash
 > pip install py-micro-hil --break-system-packages
@@ -51,19 +74,13 @@ pip install -e .
 
 ### dependencies
 
-```
-pymodbus, pytest, smbus2, spidev, pyserial
-```
+Core (all platforms): `pyserial`, `PyYAML`, `pymodbus`, `jinja2`, `termcolor`.
 
-### Developer setup
+Optional extra **`[rpi]`** (Raspberry Pi hardware): `RPi.GPIO`, `spidev`, `smbus2`.
 
-For development and contribution:
+Developer tools: `pytest`, `pytest-cov`, `flake8`, `black`, `build`, `twine` (install with `.[dev]`).
 
-```bash
-git clone https://github.com/niwciu/PY_MICRO_HIL.git
-cd PY_MICRO_HIL
-pip install -e .[dev]
-```
+For day-to-day development after cloning, use `pip install -e ".[dev]"` on PC or CI, or `pip install -e ".[dev,rpi]"` on a Raspberry Pi with real hardware.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,15 +15,17 @@ authors = [
 dependencies = [
     "pyserial>=3.5",
     "PyYAML>=6.0.2",
-    "RPi.GPIO>=0.7",
-    "spidev>=3.6",
     "pymodbus>=3.11.4",
-    "smbus2>=0.4",
     "jinja2>=3.1",
     "termcolor>=3.2"
 ]
 
 [project.optional-dependencies]
+rpi = [
+    "RPi.GPIO>=0.7",
+    "spidev>=3.6",
+    "smbus2>=0.4"
+]
 dev = [
     "pytest>=7.0",
     "pytest-cov>=4.0",

--- a/src/py_micro_hil/peripherals/RPiPeripherals.py
+++ b/src/py_micro_hil/peripherals/RPiPeripherals.py
@@ -1,25 +1,49 @@
-import sys
-import re
-from py_micro_hil.utils.system import is_raspberry_pi
-import RPi.GPIO as GPIO
-import spidev
-import serial
-from smbus2 import SMBus
 import glob
-
 import logging
+import re
+import sys
+import types
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional, Union
 
+from py_micro_hil.utils.system import is_raspberry_pi
+
 ON_RPI = is_raspberry_pi()
+_mock = None
 
-if not ON_RPI:
-    from py_micro_hil.peripherals import dummyRPiPeripherals as mock
+if ON_RPI:
+    try:
+        import RPi.GPIO as GPIO  # noqa: E402
+        import spidev  # noqa: E402
+        from smbus2 import SMBus  # noqa: E402
+    except ImportError as e:
+        raise ImportError(
+            "Raspberry Pi hardware libraries are missing. Install with:\n"
+            "  pip install 'py-micro-hil[rpi]'\n"
+            "or from source:\n"
+            "  pip install -e \".[rpi]\""
+        ) from e
+else:
+    from py_micro_hil.peripherals import dummyRPiPeripherals as _mock  # noqa: E402
 
-    sys.modules["RPi.GPIO"] = mock.GPIO
-    sys.modules["spidev"] = mock.spidev
-    sys.modules["smbus2"] = type("smbus2", (), {"SMBus": mock.SMBus})
-    sys.modules["serial"] = mock.serial
+    if "RPi" not in sys.modules:
+        sys.modules["RPi"] = types.ModuleType("RPi")
+    if "RPi.GPIO" not in sys.modules:
+        sys.modules["RPi.GPIO"] = _mock.GPIO
+        sys.modules["RPi"].GPIO = _mock.GPIO
+    if "spidev" not in sys.modules:
+        sys.modules["spidev"] = _mock.spidev
+    if "smbus2" not in sys.modules:
+        sys.modules["smbus2"] = type("smbus2", (), {"SMBus": _mock.SMBus})
+
+    import RPi.GPIO as GPIO  # noqa: E402
+    import spidev  # noqa: E402
+    from smbus2 import SMBus  # noqa: E402
+
+import serial  # noqa: E402
+
+if not ON_RPI and _mock is not None:
+    sys.modules["serial"] = _mock.serial
 
 
 # Mixins for logging and resource management


### PR DESCRIPTION
There are three dependencies RPi.GPIO, spidev, smbus2 are not mandatory until there is real hardware available.
Therefore these three are made optional.